### PR TITLE
fix: update user agent sent to RetroAchievements

### DIFF
--- a/Source/Project64-core/RetroAchievements.cpp
+++ b/Source/Project64-core/RetroAchievements.cpp
@@ -122,7 +122,7 @@ static void __cdecl RebuildMenu()
 void RA_Init(HWND hMainWindow)
 {
     // initialize the DLL
-    RA_Init(hMainWindow, "LunaProject64", "3.5.5");
+    RA_InitClient(hMainWindow, "LunaProject64", "3.5.5");
     RA_SetConsoleID(N64);
     g_hWnd = hMainWindow;
 

--- a/Source/Project64-core/RetroAchievements.cpp
+++ b/Source/Project64-core/RetroAchievements.cpp
@@ -122,7 +122,7 @@ static void __cdecl RebuildMenu()
 void RA_Init(HWND hMainWindow)
 {
     // initialize the DLL
-    RA_Init(hMainWindow, RA_Project64, "1.0");
+    RA_Init(hMainWindow, "LunaProject64", "3.5.5");
     RA_SetConsoleID(N64);
     g_hWnd = hMainWindow;
 


### PR DESCRIPTION
Hi! I'm an admin at RetroAchievements 👋

Currently, Luna-Project64 is identifying itself to our server as RAProject64. This is due to the user-agent header on network calls to the server still using the RAProject64 header.

This PR updates Luna-Project64's RA integration so it self-identifies correctly as Luna-Project64.

We'd also like to reasonably consider this emulator as an option to replace RAProject64 (with RAProject64 being sundowned & us telling our users to use Luna-Project64 instead). If you're open to this discussion, we'd love to connect!